### PR TITLE
iframes / youtube embeds are sized to not be bigger than given space

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -86,3 +86,8 @@ nav {
 h1, h2, h3, h4, h5 {
   line-height: 1.5;
 }
+
+/* This sizes youtube video. It tells it not to be wider than the space it's given. */
+iframe {
+  max-width: 100%;
+}


### PR DESCRIPTION
This will make the youtube embeds on the intersectionality page responsive. 